### PR TITLE
Added SQL Server style named parameter.

### DIFF
--- a/sqlparams/_styles.py
+++ b/sqlparams/_styles.py
@@ -133,6 +133,15 @@ STYLES['named_oracle'] = NamedStyle(
 	param_quotes=True
 )
 
+# Define non-standard "named_sqlserver" parameter style.
+STYLES['named_sqlserver'] = NamedStyle(
+	name="named_sqlserver",
+	escape_char="@",
+	escape_regex="(?P<escape>{char}@)",
+	param_regex=r'(?<!@)@(?P<param>[A-Za-z_]\w*)',
+	out_format="@{param}"
+)
+
 # Define standard "numeric" parameter style.
 STYLES['numeric'] = NumericStyle(
 	name="numeric",


### PR DESCRIPTION
Added SQL Server style (i.e. @param_name style) named parameter.

```python
>>> from sqlparams import SQLParams
>>> formatter = SQLParams('named_sqlserver', 'qmark')
>>> formatter.format('select * from Test where id = @id', {'id': 10})
('select * from Test where id = ?', [10])
```